### PR TITLE
Fix minor errors and continue on invalid ids but warn user

### DIFF
--- a/mayalookassigner/app.py
+++ b/mayalookassigner/app.py
@@ -14,6 +14,7 @@ import maya.api.OpenMaya as om
 
 from . import widgets
 from . import commands
+from .version import version
 
 module = sys.modules[__name__]
 module.window = None
@@ -32,7 +33,10 @@ class App(QtWidgets.QWidget):
         filename = commands.get_workfile()
 
         self.setObjectName("lookManager")
-        self.setWindowTitle("Look Manager 1.3.0 - [{}]".format(filename))
+        self.setWindowTitle("Look Manager {version} - [{filename}]".format(
+            version=version,
+            filename=filename
+        ))
         self.setWindowFlags(QtCore.Qt.Window)
         self.setParent(parent)
 

--- a/mayalookassigner/commands.py
+++ b/mayalookassigner/commands.py
@@ -86,7 +86,9 @@ def get_all_asset_nodes():
 
         # Gather all information
         container_name = container["objectName"]
-        nodes += cmds.sets(container_name, query=True, nodesOnly=True) or []
+        members = cmds.sets(container_name, query=True, nodesOnly=True) or []
+        members = cmds.ls(members, long=True, type="dagNode")
+        nodes += members
 
     return nodes
 
@@ -135,7 +137,15 @@ def create_items_from_nodes(nodes):
         return asset_view_items
 
     for _id, id_nodes in id_hashes.items():
-        asset = io.find_one({"_id": io.ObjectId(_id)},
+
+        try:
+            database_id = io.ObjectId(_id)
+        except io.InvalidId:
+            log.warning("Invalid ObjectId '%s' on nodes: %s" %
+                        (_id, id_nodes))
+            continue
+
+        asset = io.find_one({"_id": database_id},
                             projection={"name": True})
 
         # Skip if asset id is not found

--- a/mayalookassigner/version.py
+++ b/mayalookassigner/version.py
@@ -1,0 +1,10 @@
+
+VERSION_MAJOR = 1
+VERSION_MINOR = 3
+VERSION_PATCH = 1
+
+version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
+version = '%i.%i.%i' % version_info
+__version__ = version
+
+__all__ = ['version', 'version_info', '__version__']

--- a/mayalookassigner/widgets.py
+++ b/mayalookassigner/widgets.py
@@ -100,8 +100,6 @@ class AssetOutliner(QtWidgets.QWidget):
                 items = commands.create_items_from_nodes(nodes)
                 self.add_items(items)
 
-        return len(items) > 0
-
     def get_selected_assets(self):
         """Add all selected items from the current scene"""
 


### PR DESCRIPTION
This is a stability update that fixes some minor issues when there are invalid ids present, now it correctly proceeds to process all nodes as opposed to stopping and raising no errors (it was silent somehow, the InvalidId error somehow does not get raised to Maya script editor). A warning will now be shown when invalid ids are found.

This also includes a *version.py* file so we can easily bump and identify versions.