### PR TITLE
Update to match with new tools locations since Avalon 5.4.0

### DIFF
--- a/mayalookassigner/version.py
+++ b/mayalookassigner/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
-VERSION_MINOR = 3
-VERSION_PATCH = 1
+VERSION_MINOR = 4
+VERSION_PATCH = 0
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/mayalookassigner/widgets.py
+++ b/mayalookassigner/widgets.py
@@ -3,11 +3,7 @@ from collections import defaultdict
 
 from avalon.vendor.Qt import QtWidgets, QtCore
 
-# TODO: expose this better in avalon core
-from avalon.tools.projectmanager.widget import (
-    preserve_selection,
-    preserve_expanded_rows
-)
+from avalon.tools.lib import preserve_expanded_rows, preserve_selection
 
 from . import models
 from . import commands


### PR DESCRIPTION
Since we were referencing some things from `avalon.tools` we'll need to refactor to match with the latest and greatest since Avalon 5.4.0 as some things got shuffled around in a cleanup operation.